### PR TITLE
chore(package): update browserify to version 14.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "babel-core": "^6.7.2",
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.3.0",
-    "browserify": "^14.0.0",
+    "browserify": "^14.4.0",
     "csv-parse": "^1.1.1",
     "del": "^2.2.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Closes #7, and closes #8.